### PR TITLE
feat: a job must request specific secrets

### DIFF
--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     volumes:
       - ./watch_fakeci.yml:/app/fake-ci.yml
       - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      RUST_LOG: info
     restart: unless-stopped
   watchtower:
     image: containrrr/watchtower

--- a/resources/tests/secrets_undefined.yml
+++ b/resources/tests/secrets_undefined.yml
@@ -4,8 +4,6 @@ default:
 
 pipeline:
   - name: secrets
-    secrets:
-      - MY_SECRET
     steps:
       - name: create file
         exec:

--- a/src/lib/conf.rs
+++ b/src/lib/conf.rs
@@ -92,6 +92,8 @@ pub struct FakeCIJob {
     #[serde(default)]
     pub env: Env,
     #[serde(default)]
+    pub secrets: Vec<String>,
+    #[serde(default)]
     pub volumes: Vec<String>,
 }
 


### PR DESCRIPTION
If they don't, they won't be able to access all the runner-defined secrets via a simple `env` anymore.

Closes: #42 